### PR TITLE
feat: add idea table with categories and links

### DIFF
--- a/Backend/controllers/ideasController.js
+++ b/Backend/controllers/ideasController.js
@@ -1,0 +1,51 @@
+const pool = require('../db/db');
+
+const getIdeas = async (_req, res) => {
+  try {
+    const categoriesRes = await pool.query('SELECT id, name FROM idea_categories ORDER BY id');
+    const itemsRes = await pool.query('SELECT id, category_id, title, type, url FROM idea_items ORDER BY id');
+    const categories = categoriesRes.rows.map((cat) => ({
+      id: cat.id,
+      name: cat.name,
+      cards: itemsRes.rows
+        .filter((item) => item.category_id === cat.id)
+        .map((item) => ({
+          id: item.id,
+          title: item.title,
+          type: item.type,
+          url: item.url,
+        })),
+    }));
+    res.json(categories);
+  } catch (err) {
+    console.error('Error fetching ideas', err);
+    res.status(500).json({ error: 'Error fetching ideas' });
+  }
+};
+
+const createCategory = async (req, res) => {
+  try {
+    const { name } = req.body;
+    const result = await pool.query('INSERT INTO idea_categories(name) VALUES($1) RETURNING id, name', [name]);
+    res.status(201).json(result.rows[0]);
+  } catch (err) {
+    console.error('Error creating category', err);
+    res.status(500).json({ error: 'Error creating category' });
+  }
+};
+
+const createItem = async (req, res) => {
+  try {
+    const { categoryId, title, type, url } = req.body;
+    const result = await pool.query(
+      'INSERT INTO idea_items(category_id, title, type, url) VALUES($1,$2,$3,$4) RETURNING id, category_id, title, type, url',
+      [categoryId, title, type, url]
+    );
+    res.status(201).json(result.rows[0]);
+  } catch (err) {
+    console.error('Error creating item', err);
+    res.status(500).json({ error: 'Error creating item' });
+  }
+};
+
+module.exports = { getIdeas, createCategory, createItem };

--- a/Backend/db/migrations/20240512_create_ideas_tables.sql
+++ b/Backend/db/migrations/20240512_create_ideas_tables.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS idea_categories (
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS idea_items (
+    id SERIAL PRIMARY KEY,
+    category_id INTEGER REFERENCES idea_categories(id) ON DELETE CASCADE,
+    title TEXT NOT NULL,
+    type TEXT CHECK (type IN ('pdf', 'video')) NOT NULL,
+    url TEXT NOT NULL
+);

--- a/Backend/index.js
+++ b/Backend/index.js
@@ -23,6 +23,7 @@ app.use("/api/contacto", contactoRoute);
 app.use('/api/familias', require('./routes/familiasRoutes'));
 app.use('/api/usuarios', require('./routes/usuariosRoutes'));
 app.use('/api/productos', require('./routes/productosRoutes'));
+app.use('/api/ideas', require('./routes/ideasRoutes'));
 app.use('/api/login', require('./routes/authRoutes'));
 
 // ✅ 4. Archivos estáticos

--- a/Backend/routes/ideasRoutes.js
+++ b/Backend/routes/ideasRoutes.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const router = express.Router();
+const { getIdeas, createCategory, createItem } = require('../controllers/ideasController');
+
+router.get('/', getIdeas);
+router.post('/categories', createCategory);
+router.post('/items', createItem);
+
+module.exports = router;

--- a/GammaVase/src/components/Admin/IdeasAdmin.jsx
+++ b/GammaVase/src/components/Admin/IdeasAdmin.jsx
@@ -1,0 +1,133 @@
+import React, { useState, useEffect } from "react";
+
+const IdeasAdmin = () => {
+  const [categories, setCategories] = useState([]);
+  const [catName, setCatName] = useState("");
+  const [newCard, setNewCard] = useState({ title: "", type: "pdf", url: "", categoryId: "" });
+
+  useEffect(() => {
+    fetch("http://localhost:3000/api/ideas")
+      .then((res) => res.json())
+      .then((data) => setCategories(data))
+      .catch((err) => console.error("Error al cargar ideas", err));
+  }, []);
+
+  const addCategory = async () => {
+    if (!catName.trim()) return;
+    try {
+      const res = await fetch("http://localhost:3000/api/ideas/categories", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: catName.trim() }),
+      });
+      const data = await res.json();
+      setCategories([...categories, { ...data, cards: [] }]);
+      setCatName("");
+    } catch (err) {
+      console.error("Error al agregar categoría", err);
+    }
+  };
+
+  const addCard = async () => {
+    const { title, type, url, categoryId } = newCard;
+    if (!title.trim() || !url.trim() || !categoryId) return;
+    try {
+      const res = await fetch("http://localhost:3000/api/ideas/items", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          categoryId,
+          title: title.trim(),
+          type,
+          url: url.trim(),
+        }),
+      });
+      const data = await res.json();
+      setCategories((prev) =>
+        prev.map((cat) =>
+          cat.id === Number(categoryId)
+            ? { ...cat, cards: [...cat.cards, data] }
+            : cat
+        )
+      );
+      setNewCard({ title: "", type: "pdf", url: "", categoryId: "" });
+    } catch (err) {
+      console.error("Error al agregar tarjeta", err);
+    }
+  };
+
+  return (
+    <div className="admin-section">
+      <h2>Ideas</h2>
+      <div className="idea-category-form">
+        <input
+          type="text"
+          placeholder="Nombre de la categoría"
+          value={catName}
+          onChange={(e) => setCatName(e.target.value)}
+        />
+        <button onClick={addCategory}>Agregar categoría</button>
+      </div>
+
+      <div className="idea-subcard-form">
+        <select
+          value={newCard.categoryId}
+          onChange={(e) =>
+            setNewCard({ ...newCard, categoryId: e.target.value })
+          }
+        >
+          <option value="">Selecciona categoría</option>
+          {categories.map((cat) => (
+            <option key={cat.id} value={cat.id}>
+              {cat.name}
+            </option>
+          ))}
+        </select>
+        <input
+          type="text"
+          placeholder="Título"
+          value={newCard.title}
+          onChange={(e) => setNewCard({ ...newCard, title: e.target.value })}
+        />
+        <select
+          value={newCard.type}
+          onChange={(e) => setNewCard({ ...newCard, type: e.target.value })}
+        >
+          <option value="pdf">PDF</option>
+          <option value="video">Video</option>
+        </select>
+        <input
+          type="text"
+          placeholder="URL"
+          value={newCard.url}
+          onChange={(e) => setNewCard({ ...newCard, url: e.target.value })}
+        />
+        <button onClick={addCard}>Agregar tarjeta</button>
+      </div>
+
+      {categories.map((cat) => (
+        <div key={cat.id}>
+          <h3>{cat.name}</h3>
+          <ul>
+            {cat.cards.map((card) => (
+              <li key={card.id}>
+                {card.title}{" "}
+                {card.type === "pdf" ? (
+                  <a href={card.url} target="_blank" rel="noopener noreferrer">
+                    PDF
+                  </a>
+                ) : (
+                  <a href={card.url} target="_blank" rel="noopener noreferrer">
+                    Video
+                  </a>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default IdeasAdmin;

--- a/GammaVase/src/components/AnimatedRoutes.jsx
+++ b/GammaVase/src/components/AnimatedRoutes.jsx
@@ -9,6 +9,7 @@ import Empresa from "../pages/Empresa/Empresa";
 import ProductoDetalle from "../pages/Catalogo/ProductoDetalle";
 import Ideas from "../pages/Ideas/Ideas";
 import RopaAccesorios from "../../src/pages/Ideas/RopaAccesorios";
+import DecoracionHogar from "../../src/pages/Ideas/DecoracionHogar";
 import IdeasTable from "../pages/Ideas/IdeasTable";
 import Login from "../pages/Login/Login";
 import AdminPanel from "../pages/AdminPanel/AdminPanel";
@@ -29,6 +30,7 @@ export default function AnimatedRoutes() {
         <Route path="/ideas" element={<Ideas />} />
         <Route path="/tabla-ideas" element={<IdeasTable />} />
         <Route path="/ropa-accesorios" element={<RopaAccesorios />} />
+        <Route path="/decoracion-hogar" element={<DecoracionHogar />} />
         <Route path="/login" element={<Login />} />
         <Route path="/admin" element={<AdminPanel />} />
         <Route path="/catalogo" element={<Catalogo />} />

--- a/GammaVase/src/components/AnimatedRoutes.jsx
+++ b/GammaVase/src/components/AnimatedRoutes.jsx
@@ -9,6 +9,7 @@ import Empresa from "../pages/Empresa/Empresa";
 import ProductoDetalle from "../pages/Catalogo/ProductoDetalle";
 import Ideas from "../pages/Ideas/Ideas";
 import RopaAccesorios from "../../src/pages/Ideas/RopaAccesorios";
+import IdeasTable from "../pages/Ideas/IdeasTable";
 import Login from "../pages/Login/Login";
 import AdminPanel from "../pages/AdminPanel/AdminPanel";
 import Contacto from "../pages/Contacto/Contacto";
@@ -26,6 +27,7 @@ export default function AnimatedRoutes() {
         <Route path="/" element={<Home />} />
         <Route path="/empresa" element={<Empresa />} />
         <Route path="/ideas" element={<Ideas />} />
+        <Route path="/tabla-ideas" element={<IdeasTable />} />
         <Route path="/ropa-accesorios" element={<RopaAccesorios />} />
         <Route path="/login" element={<Login />} />
         <Route path="/admin" element={<AdminPanel />} />

--- a/GammaVase/src/pages/AdminPanel/AdminPanel.jsx
+++ b/GammaVase/src/pages/AdminPanel/AdminPanel.jsx
@@ -4,6 +4,7 @@ import { motion } from "framer-motion";
 import UsuarioForm from "../../components/Admin/UsuarioForm"; // <- IMPORTANTE
 import FamiliaForm from "../../components/Admin/FamiliaForm";
 import ProductoForm from "../../components/Admin/ProductoForm";
+import IdeasAdmin from "../../components/Admin/IdeasAdmin";
 import "./AdminPanel.css";
 
 const AdminPanel = () => {
@@ -269,6 +270,7 @@ const AdminPanel = () => {
         )}
       </div>
 
+      <IdeasAdmin />
       {/* Las otras secciones como Precios e Ideas pueden seguir igual */}
     </div>
   );

--- a/GammaVase/src/pages/Ideas/DecoracionHogar.css
+++ b/GammaVase/src/pages/Ideas/DecoracionHogar.css
@@ -1,0 +1,94 @@
+@import url('https://fonts.googleapis.com/css2?family=Kaushan+Script&display=swap');
+
+.decoracion-banner {
+  background-image: url('/public/ideas/decoracionparaelhogar.jpg');
+  background-size: cover;
+  background-position: center;
+  height: 400px;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.decoracion-banner::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: #1e1e1e8d;
+  z-index: 1;
+}
+
+.decoracion-banner h1 {
+  font-size: 4rem;
+  font-family: 'Kaushan Script', cursive;
+  color: #fff;
+  z-index: 1;
+  letter-spacing: 2px;
+}
+
+.logo-gamma {
+  position: absolute;
+  top: 15px;
+  left: 40px;
+  height: 70px;
+  z-index: 1;
+}
+
+.decoracion-subtitle {
+  text-align: center;
+  font-size: 2rem;
+  color: #E75EC0;
+  font-weight: bold;
+  margin: 2rem auto 1.5rem;
+  padding: 0.5rem 1.5rem;
+  background-color: #ffffff;
+  font-family: 'Kaushan Script', cursive;
+  border-radius: 15px;
+  width: fit-content;
+  max-width: 90%;
+  letter-spacing: 2px;
+}
+
+.decoracion-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+  padding: 0 2rem;
+  max-width: 1100px;
+  margin: 0 auto;
+  margin-bottom: 3rem;
+}
+
+.decoracion-card {
+  padding: 2rem;
+  position: relative;
+  height: 150px;
+  border-radius: 8px;
+  overflow: hidden;
+  background-size: cover;
+  background-position: center;
+  transition: transform 0.2s ease;
+  cursor: pointer;
+}
+
+.decoracion-card:hover {
+  transform: scale(1.03);
+}
+
+.decoracion-overlay {
+  letter-spacing: 2px;
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: bold;
+  font-size: 1.5rem;
+  font-family: 'Kaushan Script', cursive;
+  text-align: center;
+  padding: 0.5rem;
+}
+

--- a/GammaVase/src/pages/Ideas/DecoracionHogar.jsx
+++ b/GammaVase/src/pages/Ideas/DecoracionHogar.jsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import './DecoracionHogar.css';
+import TijerasImage from "../../components/Empresa/TijerasImage";
+
+const DecoracionHogar = () => {
+  const subcategorias = [
+    { titulo: 'Cojines', imagen: '/ideas/cojines.jpg', pdf: '/pdfs/cojines.pdf' },
+    { titulo: 'Mantas', imagen: '/ideas/mantas.jpg', video: 'https://youtu.be/mantas' },
+    { titulo: 'Cestos', imagen: '/ideas/cestos.jpg', pdf: '/pdfs/cestos.pdf' },
+    { titulo: 'Tapetes', imagen: '/ideas/tapetes.jpg', video: 'https://youtu.be/tapetes' },
+    { titulo: 'Portavelas', imagen: '/ideas/portavelas.jpg', pdf: '/pdfs/portavelas.pdf' },
+    { titulo: 'Macramé', imagen: '/ideas/macrame.jpg', video: 'https://youtu.be/macrame' },
+  ];
+
+  const handleCardClick = (item) => {
+    if (item.pdf) {
+      const link = document.createElement('a');
+      link.href = item.pdf;
+      link.download = '';
+      link.click();
+    } else if (item.video) {
+      window.open(item.video, '_blank');
+    }
+  };
+
+  return (
+    <div className="decoracion-page">
+      <div className="decoracion-banner">
+        <img src="/logo.png" alt="Logo Gamma" className="logo-gamma" />
+        <h1>Decoración para el Hogar</h1>
+      </div>
+
+      <TijerasImage />
+
+      <h2 className="decoracion-subtitle">Archivos</h2>
+
+      <div className="decoracion-grid">
+        {subcategorias.map((item, index) => (
+          <div
+            key={index}
+            className="decoracion-card"
+            style={{ backgroundImage: `url(${item.imagen})` }}
+            onClick={() => handleCardClick(item)}
+          >
+            <div className="decoracion-overlay">
+              <p>{item.titulo}</p>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default DecoracionHogar;
+

--- a/GammaVase/src/pages/Ideas/Ideas.css
+++ b/GammaVase/src/pages/Ideas/Ideas.css
@@ -115,3 +115,12 @@
   height: 100px;
   z-index: 2;
 }
+
+.ideas-table-link {
+  display: block;
+  margin: 2rem auto 0;
+  text-align: center;
+  color: #e75ec0;
+  font-weight: bold;
+  text-decoration: none;
+}

--- a/GammaVase/src/pages/Ideas/Ideas.jsx
+++ b/GammaVase/src/pages/Ideas/Ideas.jsx
@@ -74,6 +74,10 @@ const Ideas = () => {
             );
           })}
         </div>
+
+        <Link to="/tabla-ideas" className="ideas-table-link">
+          Crear tabla de ideas
+        </Link>
       </div>
     </motion.div>
   );

--- a/GammaVase/src/pages/Ideas/Ideas.jsx
+++ b/GammaVase/src/pages/Ideas/Ideas.jsx
@@ -14,6 +14,7 @@ const Ideas = () => {
     {
       titulo: "Decoración para el hogar",
       imagen: "/ideas/decoracionparaelhogar.jpg",
+      link: "/decoracion-hogar",
     },
     { titulo: "Amigurumis", imagen: "/ideas/amigurimus.png" },
     {

--- a/GammaVase/src/pages/Ideas/Ideas.jsx
+++ b/GammaVase/src/pages/Ideas/Ideas.jsx
@@ -76,7 +76,7 @@ const Ideas = () => {
         </div>
 
         <Link to="/tabla-ideas" className="ideas-table-link">
-          Crear tabla de ideas
+          Ver tabla de ideas
         </Link>
       </div>
     </motion.div>

--- a/GammaVase/src/pages/Ideas/IdeasTable.css
+++ b/GammaVase/src/pages/Ideas/IdeasTable.css
@@ -1,0 +1,38 @@
+.idea-table {
+  padding: 2rem;
+  background-color: #f0ede8;
+}
+
+.add-category {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.add-category input {
+  flex: 1;
+  padding: 0.5rem;
+}
+
+.category {
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  padding: 1rem;
+  margin-bottom: 1rem;
+  background-color: #fff;
+}
+
+.subcard-form {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.subcard-form input,
+.subcard-form select {
+  padding: 0.4rem;
+}
+
+.subcard-form button {
+  padding: 0.4rem 0.8rem;
+}

--- a/GammaVase/src/pages/Ideas/IdeasTable.jsx
+++ b/GammaVase/src/pages/Ideas/IdeasTable.jsx
@@ -1,80 +1,25 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import "./IdeasTable.css";
-
-const SubCardForm = ({ onAdd }) => {
-  const [title, setTitle] = useState("");
-  const [type, setType] = useState("pdf");
-  const [url, setUrl] = useState("");
-
-  const handleAdd = () => {
-    if (!title.trim() || !url.trim()) return;
-    onAdd({ title: title.trim(), type, url: url.trim() });
-    setTitle("");
-    setUrl("");
-  };
-
-  return (
-    <div className="subcard-form">
-      <input
-        type="text"
-        placeholder="Título"
-        value={title}
-        onChange={(e) => setTitle(e.target.value)}
-      />
-      <select value={type} onChange={(e) => setType(e.target.value)}>
-        <option value="pdf">PDF</option>
-        <option value="video">Video</option>
-      </select>
-      <input
-        type="text"
-        placeholder="URL"
-        value={url}
-        onChange={(e) => setUrl(e.target.value)}
-      />
-      <button onClick={handleAdd}>Agregar tarjeta</button>
-    </div>
-  );
-};
 
 const IdeasTable = () => {
   const [categories, setCategories] = useState([]);
-  const [catName, setCatName] = useState("");
 
-  const addCategory = () => {
-    if (!catName.trim()) return;
-    setCategories([...categories, { name: catName.trim(), cards: [] }]);
-    setCatName("");
-  };
-
-  const addCardToCategory = (index, card) => {
-    setCategories((prev) =>
-      prev.map((cat, i) =>
-        i === index ? { ...cat, cards: [...cat.cards, card] } : cat
-      )
-    );
-  };
+  useEffect(() => {
+    fetch("http://localhost:3000/api/ideas")
+      .then((res) => res.json())
+      .then((data) => setCategories(data))
+      .catch((err) => console.error("Error al cargar ideas", err));
+  }, []);
 
   return (
     <div className="idea-table">
       <h1>Tabla de Ideas</h1>
-
-      <div className="add-category">
-        <input
-          type="text"
-          placeholder="Nueva categoría"
-          value={catName}
-          onChange={(e) => setCatName(e.target.value)}
-        />
-        <button onClick={addCategory}>Agregar categoría</button>
-      </div>
-
-      {categories.map((cat, idx) => (
-        <div key={idx} className="category">
+      {categories.map((cat) => (
+        <div key={cat.id} className="category">
           <h3>{cat.name}</h3>
-          <SubCardForm onAdd={(card) => addCardToCategory(idx, card)} />
           <ul>
-            {cat.cards.map((card, j) => (
-              <li key={j}>
+            {cat.cards.map((card) => (
+              <li key={card.id}>
                 {card.title}{" "}
                 {card.type === "pdf" ? (
                   <a href={card.url} download>

--- a/GammaVase/src/pages/Ideas/IdeasTable.jsx
+++ b/GammaVase/src/pages/Ideas/IdeasTable.jsx
@@ -1,0 +1,101 @@
+import React, { useState } from "react";
+import "./IdeasTable.css";
+
+const SubCardForm = ({ onAdd }) => {
+  const [title, setTitle] = useState("");
+  const [type, setType] = useState("pdf");
+  const [url, setUrl] = useState("");
+
+  const handleAdd = () => {
+    if (!title.trim() || !url.trim()) return;
+    onAdd({ title: title.trim(), type, url: url.trim() });
+    setTitle("");
+    setUrl("");
+  };
+
+  return (
+    <div className="subcard-form">
+      <input
+        type="text"
+        placeholder="Título"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+      />
+      <select value={type} onChange={(e) => setType(e.target.value)}>
+        <option value="pdf">PDF</option>
+        <option value="video">Video</option>
+      </select>
+      <input
+        type="text"
+        placeholder="URL"
+        value={url}
+        onChange={(e) => setUrl(e.target.value)}
+      />
+      <button onClick={handleAdd}>Agregar tarjeta</button>
+    </div>
+  );
+};
+
+const IdeasTable = () => {
+  const [categories, setCategories] = useState([]);
+  const [catName, setCatName] = useState("");
+
+  const addCategory = () => {
+    if (!catName.trim()) return;
+    setCategories([...categories, { name: catName.trim(), cards: [] }]);
+    setCatName("");
+  };
+
+  const addCardToCategory = (index, card) => {
+    setCategories((prev) =>
+      prev.map((cat, i) =>
+        i === index ? { ...cat, cards: [...cat.cards, card] } : cat
+      )
+    );
+  };
+
+  return (
+    <div className="idea-table">
+      <h1>Tabla de Ideas</h1>
+
+      <div className="add-category">
+        <input
+          type="text"
+          placeholder="Nueva categoría"
+          value={catName}
+          onChange={(e) => setCatName(e.target.value)}
+        />
+        <button onClick={addCategory}>Agregar categoría</button>
+      </div>
+
+      {categories.map((cat, idx) => (
+        <div key={idx} className="category">
+          <h3>{cat.name}</h3>
+          <SubCardForm onAdd={(card) => addCardToCategory(idx, card)} />
+          <ul>
+            {cat.cards.map((card, j) => (
+              <li key={j}>
+                {card.title}{" "}
+                {card.type === "pdf" ? (
+                  <a href={card.url} download>
+                    Descargar PDF
+                  </a>
+                ) : (
+                  <a
+                    href={card.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Ver video
+                  </a>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default IdeasTable;

--- a/GammaVase/src/pages/Ideas/RopaAccesorios.jsx
+++ b/GammaVase/src/pages/Ideas/RopaAccesorios.jsx
@@ -4,13 +4,24 @@ import TijerasImage from "../../components/Empresa/TijerasImage";
 
 const RopaAccesorios = () => {
   const subcategorias = [
-    { titulo: 'Gorros', imagen: '/ideas/gorro.png' },
-    { titulo: 'bufandas', imagen: '/ideas/bufandas.jpg' },
-    { titulo: 'Guantes', imagen: '/ideas/guantes.jpg' },
-    { titulo: 'Chalecos', imagen: '/ideas/chalecos.jpeg' },
-    { titulo: 'Ponchos', imagen: '/ideas/ponchos.jpg' },
-    { titulo: 'Calentadores', imagen: '/ideas/calentadores.jpeg' },
+    { titulo: 'Gorros', imagen: '/ideas/gorro.png', pdf: '/pdfs/gorros.pdf' },
+    { titulo: 'bufandas', imagen: '/ideas/bufandas.jpg', video: 'https://youtu.be/bufandas' },
+    { titulo: 'Guantes', imagen: '/ideas/guantes.jpg', pdf: '/pdfs/guantes.pdf' },
+    { titulo: 'Chalecos', imagen: '/ideas/chalecos.jpeg', video: 'https://youtu.be/chalecos' },
+    { titulo: 'Ponchos', imagen: '/ideas/ponchos.jpg', pdf: '/pdfs/ponchos.pdf' },
+    { titulo: 'Calentadores', imagen: '/ideas/calentadores.jpeg', video: 'https://youtu.be/calentadores' },
   ];
+
+  const handleCardClick = (item) => {
+    if (item.pdf) {
+      const link = document.createElement('a');
+      link.href = item.pdf;
+      link.download = '';
+      link.click();
+    } else if (item.video) {
+      window.open(item.video, '_blank');
+    }
+  };
 
   return (
     <div className="ropa-page">
@@ -33,6 +44,7 @@ const RopaAccesorios = () => {
             key={index}
             className="ropa-card"
             style={{ backgroundImage: `url(${item.imagen})` }}
+            onClick={() => handleCardClick(item)}
           >
             <div className="ropa-overlay">
               <p>{item.titulo}</p>


### PR DESCRIPTION
## Summary
- add IdeasTable component to create categories and subcards with PDF or video links
- wire new table into routing and link from ideas page
- style link and table layout

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 'motion' is defined but never used)


------
https://chatgpt.com/codex/tasks/task_e_689b9dd3c0308320a28640a11f6dfce3