### PR TITLE
Fix ideas admin endpoints and style ideas table

### DIFF
--- a/Backend/controllers/ideasController.js
+++ b/Backend/controllers/ideasController.js
@@ -48,4 +48,26 @@ const createItem = async (req, res) => {
   }
 };
 
-module.exports = { getIdeas, createCategory, createItem };
+const deleteCategory = async (req, res) => {
+  try {
+    const { id } = req.params;
+    await pool.query('DELETE FROM idea_categories WHERE id=$1', [id]);
+    res.sendStatus(204);
+  } catch (err) {
+    console.error('Error deleting category', err);
+    res.status(500).json({ error: 'Error deleting category' });
+  }
+};
+
+const deleteItem = async (req, res) => {
+  try {
+    const { id } = req.params;
+    await pool.query('DELETE FROM idea_items WHERE id=$1', [id]);
+    res.sendStatus(204);
+  } catch (err) {
+    console.error('Error deleting item', err);
+    res.status(500).json({ error: 'Error deleting item' });
+  }
+};
+
+module.exports = { getIdeas, createCategory, createItem, deleteCategory, deleteItem };

--- a/Backend/routes/ideasRoutes.js
+++ b/Backend/routes/ideasRoutes.js
@@ -1,9 +1,11 @@
 const express = require('express');
 const router = express.Router();
-const { getIdeas, createCategory, createItem } = require('../controllers/ideasController');
+const { getIdeas, createCategory, createItem, deleteCategory, deleteItem } = require('../controllers/ideasController');
 
 router.get('/', getIdeas);
 router.post('/categories', createCategory);
 router.post('/items', createItem);
+router.delete('/categories/:id', deleteCategory);
+router.delete('/items/:id', deleteItem);
 
 module.exports = router;

--- a/GammaVase/src/pages/AdminPanel/AdminPanel.css
+++ b/GammaVase/src/pages/AdminPanel/AdminPanel.css
@@ -63,6 +63,35 @@ th {
   background-color: #f9f9f9;
 }
 
+/* Tabla de Ideas */
+.ideas-table {
+  width: 100%;
+  border-collapse: collapse;
+  background-color: #fff;
+  border: 1px solid #ccc;
+  box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
+}
+
+.ideas-table th,
+.ideas-table td {
+  padding: 0.75rem 1rem;
+  border: 1px solid #ccc;
+  text-align: left;
+}
+
+.ideas-table th {
+  background-color: #f9f9f9;
+  font-weight: 600;
+}
+
+.ideas-table tbody tr:nth-child(even) {
+  background-color: #fafafa;
+}
+
+.ideas-table tbody tr:hover {
+  background-color: #f1f1f1;
+}
+
 /* === Estilos para modales (Usuarios, Familias, Productos, Ideas) === */
 .modal-overlay {
   position: fixed;

--- a/GammaVase/src/pages/AdminPanel/AdminPanel.jsx
+++ b/GammaVase/src/pages/AdminPanel/AdminPanel.jsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from "react";
 import { Link } from "react-router-dom";
-import { motion } from "framer-motion";
 import UsuarioForm from "../../components/Admin/UsuarioForm"; // <- IMPORTANTE
 import FamiliaForm from "../../components/Admin/FamiliaForm";
 import ProductoForm from "../../components/Admin/ProductoForm";
@@ -152,7 +151,7 @@ const AdminPanel = () => {
     const nombre = (nombreDesdeForm ?? newCatName).trim();
     if (!nombre) return;
     try {
-      const res = await fetch("http://localhost:3000/api/ideas", {
+      const res = await fetch("http://localhost:3000/api/ideas/categories", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ name: nombre }),
@@ -169,7 +168,7 @@ const AdminPanel = () => {
   const eliminarCategoria = async (id) => {
     if (!window.confirm("¿Eliminar esta categoría y sus tarjetas?")) return;
     try {
-      const res = await fetch(`http://localhost:3000/api/ideas/${id}`, {
+      const res = await fetch(`http://localhost:3000/api/ideas/categories/${id}`, {
         method: "DELETE",
       });
       if (!res.ok) throw new Error("No se pudo eliminar");
@@ -182,18 +181,16 @@ const AdminPanel = () => {
   const agregarTarjeta = async () => {
     if (!newCardCatId || !newCardTitle.trim() || !newCardUrl.trim()) return;
     try {
-      const res = await fetch(
-        `http://localhost:3000/api/ideas/${newCardCatId}/cards`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            title: newCardTitle.trim(),
-            type: newCardType, // "pdf" | "video"
-            url: newCardUrl.trim(),
-          }),
-        }
-      );
+      const res = await fetch("http://localhost:3000/api/ideas/items", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          categoryId: newCardCatId,
+          title: newCardTitle.trim(),
+          type: newCardType, // "pdf" | "video"
+          url: newCardUrl.trim(),
+        }),
+      });
       if (!res.ok) throw new Error("No se pudo agregar la tarjeta");
       const nueva = await res.json();
       setIdeas((prev) =>
@@ -216,7 +213,7 @@ const AdminPanel = () => {
     if (!window.confirm("¿Eliminar esta tarjeta?")) return;
     try {
       const res = await fetch(
-        `http://localhost:3000/api/ideas/${catId}/cards/${cardId}`,
+        `http://localhost:3000/api/ideas/items/${cardId}`,
         { method: "DELETE" }
       );
       if (!res.ok) throw new Error("No se pudo eliminar la tarjeta");
@@ -423,7 +420,7 @@ function IdeaForm({ onClose, onSave }) {
         </h2>
 
         {/* Tabla de categorías */}
-        <table>
+        <table className="ideas-table">
           <thead>
             <tr>
               <th>ID</th>


### PR DESCRIPTION
## Summary
- add delete endpoints for idea categories and items
- update admin panel to use new endpoints and style ideas table consistently

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 12 errors, 1 warning)*

------
https://chatgpt.com/codex/tasks/task_e_68a12e2b8e7883208228356c98c62402