### PR TITLE
Fix ideas admin endpoints and style ideas table

### DIFF
--- a/Backend/controllers/ideasController.js
+++ b/Backend/controllers/ideasController.js
@@ -48,4 +48,28 @@ const createItem = async (req, res) => {
   }
 };
 
-module.exports = { getIdeas, createCategory, createItem };
+const deleteCategory = async (req, res) => {
+  try {
+    const { id } = req.params;
+    // Remove child items first to avoid foreign key violations
+    await pool.query('DELETE FROM idea_items WHERE category_id=$1', [id]);
+    await pool.query('DELETE FROM idea_categories WHERE id=$1', [id]);
+    res.sendStatus(204);
+  } catch (err) {
+    console.error('Error deleting category', err);
+    res.status(500).json({ error: 'Error deleting category' });
+  }
+};
+
+const deleteItem = async (req, res) => {
+  try {
+    const { id } = req.params;
+    await pool.query('DELETE FROM idea_items WHERE id=$1', [id]);
+    res.sendStatus(204);
+  } catch (err) {
+    console.error('Error deleting item', err);
+    res.status(500).json({ error: 'Error deleting item' });
+  }
+};
+
+module.exports = { getIdeas, createCategory, createItem, deleteCategory, deleteItem };

--- a/Backend/routes/ideasRoutes.js
+++ b/Backend/routes/ideasRoutes.js
@@ -1,9 +1,11 @@
 const express = require('express');
 const router = express.Router();
-const { getIdeas, createCategory, createItem } = require('../controllers/ideasController');
+const { getIdeas, createCategory, createItem, deleteCategory, deleteItem } = require('../controllers/ideasController');
 
 router.get('/', getIdeas);
 router.post('/categories', createCategory);
 router.post('/items', createItem);
+router.delete('/categories/:id', deleteCategory);
+router.delete('/items/:id', deleteItem);
 
 module.exports = router;

--- a/GammaVase/src/pages/AdminPanel/AdminPanel.css
+++ b/GammaVase/src/pages/AdminPanel/AdminPanel.css
@@ -63,6 +63,51 @@ th {
   background-color: #f9f9f9;
 }
 
+/* Tabla de Ideas */
+.ideas-table {
+  width: 100%;
+  border-collapse: collapse;
+  background-color: #fff;
+  border: 1px solid #ccc;
+  box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
+}
+
+.ideas-table th,
+.ideas-table td {
+  padding: 0.75rem 1rem;
+  border: 1px solid #ccc;
+  text-align: left;
+}
+
+.ideas-table th {
+  background-color: #f9f9f9;
+  font-weight: 600;
+}
+
+.ideas-table tbody tr:nth-child(even) {
+  background-color: #fafafa;
+}
+
+.ideas-table tbody tr:hover {
+  background-color: #f1f1f1;
+}
+
+.ideas-table tfoot td {
+  background-color: #f9f9f9;
+}
+
+.ideas-table tfoot input,
+.ideas-table tfoot select,
+.ideas-table tfoot button {
+  width: 100%;
+  padding: 0.5rem;
+  box-sizing: border-box;
+}
+
+.idea-item-row td {
+  background-color: #fff;
+}
+
 /* === Estilos para modales (Usuarios, Familias, Productos, Ideas) === */
 .modal-overlay {
   position: fixed;


### PR DESCRIPTION
## Summary
- cascade delete idea category items before removing the category
- show idea categories and items in one table with inline add forms
- style ideas table footer and nested rows for a consistent look

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm --prefix GammaVase run lint` *(fails: 12 errors, 1 warning)*

------
https://chatgpt.com/codex/tasks/task_e_68a12e2b8e7883208228356c98c62402