### PR TITLE
Add idea creation modal and improve card deletion

### DIFF
--- a/Backend/controllers/ideasController.js
+++ b/Backend/controllers/ideasController.js
@@ -48,4 +48,29 @@ const createItem = async (req, res) => {
   }
 };
 
-module.exports = { getIdeas, createCategory, createItem };
+const deleteCategory = async (req, res) => {
+  try {
+    const { id } = req.params;
+    // Remove child items first to avoid foreign key violations
+    await pool.query('DELETE FROM idea_items WHERE category_id=$1', [id]);
+    await pool.query('DELETE FROM idea_categories WHERE id=$1', [id]);
+    res.sendStatus(204);
+  } catch (err) {
+    console.error('Error deleting category', err);
+    res.status(500).json({ error: 'Error deleting category' });
+  }
+};
+
+const deleteItem = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const result = await pool.query('DELETE FROM idea_items WHERE id=$1', [id]);
+    if (result.rowCount === 0) return res.status(404).json({ error: 'Item not found' });
+    res.sendStatus(204);
+  } catch (err) {
+    console.error('Error deleting item', err);
+    res.status(500).json({ error: 'Error deleting item' });
+  }
+};
+
+module.exports = { getIdeas, createCategory, createItem, deleteCategory, deleteItem };

--- a/Backend/routes/ideasRoutes.js
+++ b/Backend/routes/ideasRoutes.js
@@ -1,9 +1,11 @@
 const express = require('express');
 const router = express.Router();
-const { getIdeas, createCategory, createItem } = require('../controllers/ideasController');
+const { getIdeas, createCategory, createItem, deleteCategory, deleteItem } = require('../controllers/ideasController');
 
 router.get('/', getIdeas);
 router.post('/categories', createCategory);
 router.post('/items', createItem);
+router.delete('/categories/:id', deleteCategory);
+router.delete('/items/:id', deleteItem);
 
 module.exports = router;

--- a/GammaVase/src/pages/AdminPanel/AdminPanel.css
+++ b/GammaVase/src/pages/AdminPanel/AdminPanel.css
@@ -63,6 +63,39 @@ th {
   background-color: #f9f9f9;
 }
 
+/* Tabla de Ideas */
+.ideas-table {
+  width: 100%;
+  border-collapse: collapse;
+  background-color: #fff;
+  border: 1px solid #ccc;
+  box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
+}
+
+.ideas-table th,
+.ideas-table td {
+  padding: 0.75rem 1rem;
+  border: 1px solid #ccc;
+  text-align: left;
+}
+
+.ideas-table th {
+  background-color: #f9f9f9;
+  font-weight: 600;
+}
+
+.ideas-table tbody tr:nth-child(even) {
+  background-color: #fafafa;
+}
+
+.ideas-table tbody tr:hover {
+  background-color: #f1f1f1;
+}
+
+.idea-item-row td {
+  background-color: #fff;
+}
+
 /* === Estilos para modales (Usuarios, Familias, Productos, Ideas) === */
 .modal-overlay {
   position: fixed;

--- a/GammaVase/src/pages/AdminPanel/AdminPanel.jsx
+++ b/GammaVase/src/pages/AdminPanel/AdminPanel.jsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from "react";
 import { Link } from "react-router-dom";
-import { motion } from "framer-motion";
 import UsuarioForm from "../../components/Admin/UsuarioForm"; // <- IMPORTANTE
 import FamiliaForm from "../../components/Admin/FamiliaForm";
 import ProductoForm from "../../components/Admin/ProductoForm";
@@ -19,13 +18,7 @@ const AdminPanel = () => {
   const [showIdeaForm, setShowIdeaForm] = useState(false);
 
   // === IDEAS ===
-  const [ideas, setIdeas] = useState([]);           // categorías
-  const [newCatName, setNewCatName] = useState(""); // input "Nombre de la categoría"
-
-  const [newCardCatId, setNewCardCatId] = useState(""); // select categoría para la tarjeta
-  const [newCardTitle, setNewCardTitle] = useState(""); // título de la tarjeta
-  const [newCardType, setNewCardType] = useState("pdf"); // pdf | video
-  const [newCardUrl, setNewCardUrl] = useState("");     // URL (descarga o video)
+  const [ideas, setIdeas] = useState([]); // categorías e items
 
   useEffect(() => {
     fetch("http://localhost:3000/api/familias")
@@ -148,28 +141,29 @@ const AdminPanel = () => {
   };
 
   // === HANDLERS IDEAS ===
-  const agregarCategoria = async (nombreDesdeForm) => {
-    const nombre = (nombreDesdeForm ?? newCatName).trim();
-    if (!nombre) return;
+  const agregarCategoria = async (nombre) => {
+    const nombreTrim = nombre.trim();
+    if (!nombreTrim) return null;
     try {
-      const res = await fetch("http://localhost:3000/api/ideas", {
+      const res = await fetch("http://localhost:3000/api/ideas/categories", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name: nombre }),
+        body: JSON.stringify({ name: nombreTrim }),
       });
       if (!res.ok) throw new Error("No se pudo agregar la categoría");
       const creada = await res.json();
       setIdeas((prev) => [...prev, { ...creada, cards: creada.cards || [] }]);
-      setNewCatName("");
+      return creada;
     } catch (e) {
       alert(e.message);
+      return null;
     }
   };
 
   const eliminarCategoria = async (id) => {
     if (!window.confirm("¿Eliminar esta categoría y sus tarjetas?")) return;
     try {
-      const res = await fetch(`http://localhost:3000/api/ideas/${id}`, {
+      const res = await fetch(`http://localhost:3000/api/ideas/categories/${id}`, {
         method: "DELETE",
       });
       if (!res.ok) throw new Error("No se pudo eliminar");
@@ -179,36 +173,26 @@ const AdminPanel = () => {
     }
   };
 
-  const agregarTarjeta = async () => {
-    if (!newCardCatId || !newCardTitle.trim() || !newCardUrl.trim()) return;
+  const agregarTarjeta = async ({ categoryId, title, type, url }) => {
     try {
-      const res = await fetch(
-        `http://localhost:3000/api/ideas/${newCardCatId}/cards`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            title: newCardTitle.trim(),
-            type: newCardType, // "pdf" | "video"
-            url: newCardUrl.trim(),
-          }),
-        }
-      );
+      const res = await fetch("http://localhost:3000/api/ideas/items", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ categoryId, title, type, url }),
+      });
       if (!res.ok) throw new Error("No se pudo agregar la tarjeta");
       const nueva = await res.json();
       setIdeas((prev) =>
         prev.map((cat) =>
-          cat.id === Number(newCardCatId)
+          cat.id === Number(categoryId)
             ? { ...cat, cards: [...(cat.cards || []), nueva] }
             : cat
         )
       );
-      setNewCardCatId("");
-      setNewCardTitle("");
-      setNewCardType("pdf");
-      setNewCardUrl("");
+      return nueva;
     } catch (e) {
       alert(e.message);
+      return null;
     }
   };
 
@@ -216,7 +200,7 @@ const AdminPanel = () => {
     if (!window.confirm("¿Eliminar esta tarjeta?")) return;
     try {
       const res = await fetch(
-        `http://localhost:3000/api/ideas/${catId}/cards/${cardId}`,
+        `http://localhost:3000/api/ideas/items/${cardId}`,
         { method: "DELETE" }
       );
       if (!res.ok) throw new Error("No se pudo eliminar la tarjeta");
@@ -234,13 +218,32 @@ const AdminPanel = () => {
 
 
 // === Modal simple para crear Categoría de Ideas (similar a otros forms) ===
-function IdeaForm({ onClose, onSave }) {
-  const [name, setName] = useState("");
+function IdeaForm({ onClose, categories, onAddCategory, onAddCard }) {
+  const [catName, setCatName] = useState("");
+  const [catId, setCatId] = useState("");
+  const [title, setTitle] = useState("");
+  const [type, setType] = useState("pdf");
+  const [url, setUrl] = useState("");
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
-    if (!name.trim()) return;
-    onSave({ name: name.trim() });
+    let usedCatId = catId;
+    if (catName.trim()) {
+      const nueva = await onAddCategory(catName.trim());
+      if (nueva) usedCatId = nueva.id;
+    }
+    if (!usedCatId || !title.trim() || !url.trim()) return;
+    await onAddCard({
+      categoryId: usedCatId,
+      title: title.trim(),
+      type,
+      url: url.trim(),
+    });
+    setCatName("");
+    setCatId("");
+    setTitle("");
+    setType("pdf");
+    setUrl("");
     onClose();
   };
 
@@ -248,19 +251,37 @@ function IdeaForm({ onClose, onSave }) {
     <div className="modal-overlay">
       <div className="modal-content">
         <div className="modal-header">
-          <h3>Nueva categoría</h3>
+          <h3>Nueva idea</h3>
           <button className="close-btn" onClick={onClose}>×</button>
         </div>
         <form onSubmit={handleSubmit} className="modal-body">
-          <label>Nombre</label>
+          <label>Nueva categoría (opcional)</label>
           <input
-            value={name}
-            onChange={(e) => setName(e.target.value)}
+            value={catName}
+            onChange={(e) => setCatName(e.target.value)}
             placeholder="Nombre de la categoría"
           />
+          <label>Seleccionar categoría</label>
+          <select value={catId} onChange={(e) => setCatId(e.target.value)}>
+            <option value="">Selecciona categoría</option>
+            {categories.map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.name}
+              </option>
+            ))}
+          </select>
+          <label>Título</label>
+          <input value={title} onChange={(e) => setTitle(e.target.value)} />
+          <label>Tipo</label>
+          <select value={type} onChange={(e) => setType(e.target.value)}>
+            <option value="pdf">PDF</option>
+            <option value="video">Video</option>
+          </select>
+          <label>URL del recurso</label>
+          <input value={url} onChange={(e) => setUrl(e.target.value)} />
           <div className="modal-actions">
             <button type="button" onClick={onClose}>Cancelar</button>
-            <button type="submit">Guardar</button>
+            <button type="submit">Agregar</button>
           </div>
         </form>
       </div>
@@ -422,26 +443,42 @@ function IdeaForm({ onClose, onSave }) {
           </span>
         </h2>
 
-        {/* Tabla de categorías */}
-        <table>
+        {/* Tabla de categorías y tarjetas */}
+        <table className="ideas-table">
           <thead>
             <tr>
               <th>ID</th>
-              <th>Categoría</th>
-              <th>Subitems</th>
+              <th>Categoría / Tarjeta</th>
+              <th>Tipo</th>
               <th>Acciones</th>
             </tr>
           </thead>
           <tbody>
             {ideas.map((cat) => (
-              <tr key={cat.id}>
-                <td>{cat.id}</td>
-                <td>{cat.name}</td>
-                <td>{(cat.cards || []).length}</td>
-                <td>
-                  <button onClick={() => eliminarCategoria(cat.id)}>🗑️</button>
-                </td>
-              </tr>
+              <React.Fragment key={cat.id}>
+                <tr>
+                  <td>{cat.id}</td>
+                  <td>{cat.name}</td>
+                  <td>{(cat.cards || []).length} subitems</td>
+                  <td>
+                    <button onClick={() => eliminarCategoria(cat.id)}>🗑️</button>
+                  </td>
+                </tr>
+                {(cat.cards || []).map((card) => (
+                  <tr key={card.id} className="idea-item-row">
+                    <td></td>
+                    <td>
+                      <Link to={card.url} target="_blank" rel="noreferrer">
+                        {card.title}
+                      </Link>
+                    </td>
+                    <td>{card.type === "pdf" ? "PDF" : "Video"}</td>
+                    <td>
+                      <button onClick={() => eliminarTarjeta(cat.id, card.id)}>🗑️</button>
+                    </td>
+                  </tr>
+                ))}
+              </React.Fragment>
             ))}
             {ideas.length === 0 && (
               <tr>
@@ -453,85 +490,13 @@ function IdeaForm({ onClose, onSave }) {
           </tbody>
         </table>
         {showIdeaForm && (
-          <IdeaForm onClose={() => setShowIdeaForm(false)} onSave={({ name }) => agregarCategoria(name)} />
+          <IdeaForm
+            onClose={() => setShowIdeaForm(false)}
+            categories={ideas}
+            onAddCategory={agregarCategoria}
+            onAddCard={agregarTarjeta}
+          />
         )}
-
-        {/* Form inline: Agregar categoría */}
-        <div style={{ marginTop: ".5rem" }}>
-          <input
-            placeholder="Nombre de la categoría"
-            value={newCatName}
-            onChange={(e) => setNewCatName(e.target.value)}
-            style={{ marginRight: ".5rem" }}
-          />
-          <button onClick={agregarCategoria}>Agregar categoría</button>
-        </div>
-
-        {/* Form inline: Agregar tarjeta a una categoría */}
-        <div style={{ marginTop: ".5rem", display: "grid", gap: ".5rem",
-                      gridTemplateColumns: "200px 1fr 120px 1fr 150px" }}>
-          <select
-            value={newCardCatId}
-            onChange={(e) => setNewCardCatId(e.target.value)}
-          >
-            <option value="">Selecciona categoría</option>
-            {ideas.map((c) => (
-              <option key={c.id} value={c.id}>
-                {c.name}
-              </option>
-            ))}
-          </select>
-
-          <input
-            placeholder="Título"
-            value={newCardTitle}
-            onChange={(e) => setNewCardTitle(e.target.value)}
-          />
-
-          <select
-            value={newCardType}
-            onChange={(e) => setNewCardType(e.target.value)}
-          >
-            <option value="pdf">PDF</option>
-            <option value="video">Video</option>
-          </select>
-
-          <input
-            placeholder="URL (archivo o video)"
-            value={newCardUrl}
-            onChange={(e) => setNewCardUrl(e.target.value)}
-          />
-
-          <button
-            onClick={agregarTarjeta}
-            disabled={!newCardCatId || !newCardTitle || !newCardUrl}
-          >
-            Agregar tarjeta
-          </button>
-        </div>
-
-        {/* Lista rápida de tarjetas por categoría */}
-        <div style={{ marginTop: "0.75rem" }}>
-          {ideas.map((cat) => (
-            <div key={cat.id} style={{ marginBottom: ".5rem" }}>
-              <strong>{cat.name}:</strong>{" "}
-              {(cat.cards || []).map((card, idx) => (
-                <span key={card.id || idx} style={{ marginRight: "10px" }}>
-                  <Link to={card.url} target="_blank" rel="noreferrer">
-                    {card.title} {card.type === "pdf" ? "📄" : "▶️"}
-                  </Link>{" "}
-                  <button
-                    title="Eliminar tarjeta"
-                    onClick={() => eliminarTarjeta(cat.id, card.id)}
-                    style={{ marginLeft: "4px" }}
-                  >
-                    🗑️
-                  </button>
-                </span>
-              ))}
-            </div>
-          ))}
-        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- validate idea card deletion by returning 404 when item is missing
- replace table footers with a modal that adds categories and cards in one flow
- refine ideas table styling to match other admin tables

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm --prefix GammaVase run lint` *(fails: 12 errors, 1 warning)*

------
https://chatgpt.com/codex/tasks/task_e_68a12e2b8e7883208228356c98c62402