### PR TITLE
feat: tweak navbar and home search styles

### DIFF
--- a/GammaVase/src/pages/Home/Home.module.css
+++ b/GammaVase/src/pages/Home/Home.module.css
@@ -8,18 +8,37 @@
   justify-content: center;
   padding: 4rem 1rem;
   text-align: center;
+  position: relative;
+  overflow: hidden;
+}
+
+.searchSection::before {
+  content: "";
+  position: absolute;
+  width: 500px;
+  height: 500px;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: radial-gradient(circle, #F328B8 0%, rgba(243, 40, 184, 0) 70%);
+  border-radius: 50%;
+  z-index: 0;
 }
 
 .searchTitle {
   font-size: 2rem;
   color: #fff;
   margin-bottom: 1.5rem;
+  position: relative;
+  z-index: 1;
 }
 
 .searchForm {
   display: flex;
   align-items: center;
   gap: 0.5rem;
+  position: relative;
+  z-index: 1;
 }
 
 .searchInput {
@@ -56,6 +75,8 @@
   background: white;
   border: 1px solid #ccc;
   border-radius: 8px;
+  position: relative;
+  z-index: 1;
 }
 
 .sugerencias li {

--- a/GammaVase/src/styles/navbar.css
+++ b/GammaVase/src/styles/navbar.css
@@ -1,10 +1,12 @@
 @import url("https://fonts.googleapis.com/css2?family=Montaga&display=swap");
 
 .navbar {
-  position: relative;
+  position: sticky;
+  top: 0;
   background-color: #f0ede8;
   padding: 1.5rem;
   z-index: 1000;
+  border-bottom: 1px solid #ccc;
 }
 
 .navbar-container {


### PR DESCRIPTION
## Summary
- make navbar sticky with thin gray border
- apply radial gradient overlay to home search section

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4c8b28b9c8320a69f1d5daccbdf51