### PR TITLE
feat: add responsive styles across pages

### DIFF
--- a/GammaVase/src/components/Footer.css
+++ b/GammaVase/src/components/Footer.css
@@ -52,3 +52,21 @@
   color: #8888ff;
   font-weight: bold;
 }
+
+@media (max-width: 600px) {
+  .footer-container {
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    gap: 1rem;
+  }
+
+  .footer-contact {
+    align-items: center;
+  }
+
+  .footer-logo img {
+    height: 60px;
+    margin-bottom: 1rem;
+  }
+}

--- a/GammaVase/src/pages/AdminPanel/AdminPanel.css
+++ b/GammaVase/src/pages/AdminPanel/AdminPanel.css
@@ -197,3 +197,21 @@ th {
   background: #e1e1e1;
   color: #333;
 }
+@media (max-width: 768px) {
+  .admin-panel {
+    padding: 1rem;
+  }
+  .admin-banner {
+    height: 80px;
+  }
+  .admin-banner h1 {
+    font-size: 1.5rem;
+  }
+  .admin-section {
+    padding: 1rem;
+    overflow-x: auto;
+  }
+  table {
+    min-width: 600px;
+  }
+}

--- a/GammaVase/src/pages/Catalogo/catalogo.css
+++ b/GammaVase/src/pages/Catalogo/catalogo.css
@@ -249,3 +249,29 @@
   display: flex;
   justify-content: center;
 }
+@media (max-width: 768px) {
+  .catalogo-container {
+    flex-direction: column;
+  }
+  .sidebar {
+    width: 100%;
+    margin-bottom: 1rem;
+  }
+  .contenido {
+    margin-left: 0;
+  }
+  .productos-grid {
+    grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  }
+  .catalogo-header {
+    flex-direction: column;
+    gap: 1rem;
+    text-align: center;
+  }
+  .titulo-catalogo {
+    font-size: 2rem;
+  }
+  .logo-catalogo {
+    height: 80px;
+  }
+}

--- a/GammaVase/src/pages/Home/Home.module.css
+++ b/GammaVase/src/pages/Home/Home.module.css
@@ -105,3 +105,23 @@
   position: relative;
   z-index: 1;
 }
+@media (max-width: 600px) {
+  .searchSection {
+    height: auto;
+    padding: 2rem 1rem;
+  }
+  .searchForm {
+    flex-direction: column;
+    width: 100%;
+  }
+  .searchInput {
+    width: 100%;
+  }
+  .sugerencias {
+    width: 100%;
+    margin-right: 0;
+  }
+  .sliderWrapper {
+    padding: 2rem 1rem;
+  }
+}

--- a/GammaVase/src/pages/Ideas/Ideas.css
+++ b/GammaVase/src/pages/Ideas/Ideas.css
@@ -124,3 +124,15 @@
   font-weight: bold;
   text-decoration: none;
 }
+@media (max-width: 600px) {
+  .ideas-banner {
+    height: 250px;
+  }
+  .ideas-banner h1 {
+    font-size: 2.5rem;
+  }
+  .ideas-subtitle {
+    font-size: 1.8rem;
+    margin-top: 1rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add mobile media queries for Home search and slider
- make Catalog and Admin Panel layouts stack on small screens
- adjust Ideas page banner and subtitle for phones

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Rollup failed to resolve import "react-toastify")*

------
https://chatgpt.com/codex/tasks/task_e_68b5ffe710008320a71aec5a7aa4fc08