### PR TITLE
Add ideas API route and style ideas categories

### DIFF
--- a/Backend/index.js
+++ b/Backend/index.js
@@ -27,6 +27,7 @@ app.use('/api/productos', require('./routes/productosRoutes'));
 app.use('/api/precios', require('./routes/preciosRoutes'));
 
 app.use('/api/login', require('./routes/authRoutes'));
+app.use('/api/ideas', require('./routes/ideasRoutes'));
 
 // ✅ 4. Archivos estáticos
 app.use('/imgCata', express.static(path.join(__dirname, '../GammaVase/public/imgCata')));

--- a/GammaVase/src/pages/Ideas/Ideas.css
+++ b/GammaVase/src/pages/Ideas/Ideas.css
@@ -116,15 +116,6 @@
   z-index: 2;
 }
 
-.ideas-table-link {
-  display: block;
-  margin: 2rem auto 0;
-  text-align: center;
-  color: #e75ec0;
-  font-weight: bold;
-  text-decoration: none;
-}
-
 /* Estilos para categorías dinámicas */
 .idea-category {
   background-color: #fff;
@@ -132,13 +123,31 @@
   border-radius: 8px;
 }
 
-.idea-category ul {
-  list-style: none;
-  padding: 0;
+.idea-items {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 1rem;
+  margin-top: 0.5rem;
 }
 
-.idea-category li {
-  margin-bottom: 0.5rem;
+.idea-item {
+  background-color: #f8f8f8;
+  border-radius: 6px;
+  padding: 0.75rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  text-align: center;
+}
+
+.idea-item h4 {
+  margin: 0 0 0.5rem;
+  font-size: 1rem;
+  color: #333;
+}
+
+.idea-item a {
+  text-decoration: none;
+  color: #e75ec0;
+  font-weight: bold;
 }
 @media (max-width: 600px) {
   .ideas-banner {

--- a/GammaVase/src/pages/Ideas/Ideas.jsx
+++ b/GammaVase/src/pages/Ideas/Ideas.jsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from "react";
 import "./Ideas.css";
 import TijerasImage from "../../components/Empresa/TijerasImage";
-import { Link } from "react-router-dom";
 import { motion } from "framer-motion";
 const MotionDiv = motion.div;
 
@@ -40,29 +39,25 @@ const Ideas = () => {
           {categories.map((cat) => (
             <div key={cat.id} className="idea-category">
               <h3>{cat.name}</h3>
-              <ul>
+              <div className="idea-items">
                 {cat.cards.map((card) => (
-                  <li key={card.id}>
-                    {card.title}{" "}
+                  <div key={card.id} className="idea-item">
+                    <h4>{card.title}</h4>
                     {card.type === "pdf" ? (
                       <a href={card.url} target="_blank" rel="noopener noreferrer">
-                        Descargar PDF
+                        📄 Descargar PDF
                       </a>
                     ) : (
                       <a href={card.url} target="_blank" rel="noopener noreferrer">
-                        Ver video
+                        🎬 Ver video
                       </a>
                     )}
-                  </li>
+                  </div>
                 ))}
-              </ul>
+              </div>
             </div>
           ))}
         </div>
-
-        <Link to="/tabla-ideas" className="ideas-table-link">
-          Ver tabla de ideas
-        </Link>
       </div>
     </MotionDiv>
   );


### PR DESCRIPTION
## Summary
- hook up `/api/ideas` to ideasRoutes in the backend
- render ideas categories as cards with title and PDF/video links
- remove unused "Ver tabla de ideas" link

## Testing
- `npm test` *(fails: Missing script: "test")*
- `timeout 5 node Backend/index.js` *(fails: Error al conectar con PostgreSQL)*

------
https://chatgpt.com/codex/tasks/task_e_68b78951e3548320bdfdfd325c9cec25