### PR TITLE
Allow image backgrounds for ideas categories and items

### DIFF
--- a/Backend/index.js
+++ b/Backend/index.js
@@ -27,6 +27,7 @@ app.use('/api/productos', require('./routes/productosRoutes'));
 app.use('/api/precios', require('./routes/preciosRoutes'));
 
 app.use('/api/login', require('./routes/authRoutes'));
+app.use('/api/ideas', require('./routes/ideasRoutes'));
 
 // ✅ 4. Archivos estáticos
 app.use('/imgCata', express.static(path.join(__dirname, '../GammaVase/public/imgCata')));

--- a/GammaVase/src/components/Admin/IdeaCategoryForm.jsx
+++ b/GammaVase/src/components/Admin/IdeaCategoryForm.jsx
@@ -2,15 +2,19 @@ import React, { useState } from "react";
 import "./UsuarioForm.css";
 
 const IdeaCategoryForm = ({ onClose, onSave }) => {
-  const [name, setName] = useState("");
+  const [form, setForm] = useState({ name: "", imageUrl: "" });
+
+  const handleChange = (e) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
 
   const handleSubmit = (e) => {
     e.preventDefault();
-    if (!name.trim()) {
+    if (!form.name.trim()) {
       alert("El nombre es obligatorio.");
       return;
     }
-    onSave(name);
+    onSave(form);
     onClose();
   };
 
@@ -22,8 +26,16 @@ const IdeaCategoryForm = ({ onClose, onSave }) => {
           <input
             type="text"
             placeholder="Nombre"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
+            name="name"
+            value={form.name}
+            onChange={handleChange}
+          />
+          <input
+            type="text"
+            placeholder="URL de imagen"
+            name="imageUrl"
+            value={form.imageUrl}
+            onChange={handleChange}
           />
           <div className="modal-actions">
             <button type="submit">Guardar</button>

--- a/GammaVase/src/components/Admin/IdeaItemForm.jsx
+++ b/GammaVase/src/components/Admin/IdeaItemForm.jsx
@@ -7,6 +7,7 @@ const IdeaItemForm = ({ categories, defaultCategoryId = "", onClose, onSave }) =
     title: "",
     type: "video",
     url: "",
+    imageUrl: "",
   });
 
   const handleChange = (e) => {
@@ -54,6 +55,12 @@ const IdeaItemForm = ({ categories, defaultCategoryId = "", onClose, onSave }) =
             name="url"
             placeholder="URL"
             value={form.url}
+            onChange={handleChange}
+          />
+          <input
+            name="imageUrl"
+            placeholder="URL de imagen"
+            value={form.imageUrl}
             onChange={handleChange}
           />
           <div className="modal-actions">

--- a/GammaVase/src/pages/AdminPanel/AdminPanel.jsx
+++ b/GammaVase/src/pages/AdminPanel/AdminPanel.jsx
@@ -202,6 +202,9 @@ const AdminPanel = () => {
         body: JSON.stringify({ name, imageUrl }),
       });
       const data = await res.json();
+      if (!res.ok) {
+        throw new Error(data.error || 'Error al guardar categoría');
+      }
       setIdeaCategories((prev) => [...prev, { ...data, cards: [] }]);
     } catch (err) {
       alert('Error al guardar categoría: ' + err.message);
@@ -216,6 +219,9 @@ const AdminPanel = () => {
         body: JSON.stringify(item),
       });
       const data = await res.json();
+      if (!res.ok) {
+        throw new Error(data.error || 'Error al guardar idea');
+      }
       setIdeaCategories((prev) =>
         prev.map((cat) =>
           cat.id === data.category_id
@@ -611,10 +617,11 @@ const AdminPanel = () => {
             ➕
           </span>
         </h2>
-        {Array.isArray(ideaCategories) && ideaCategories.map((cat) => (
-          <div key={cat.id} className="idea-admin-category">
-            <h3>
-              {cat.name}{" "}
+        {Array.isArray(ideaCategories)
+          ? ideaCategories.map((cat) => (
+              <div key={cat.id} className="idea-admin-category">
+              <h3>
+                {cat.name}{" "}
               <button
                 onClick={() => {
                   setCurrentCategory(cat.id);
@@ -662,7 +669,8 @@ const AdminPanel = () => {
               </tbody>
             </table>
           </div>
-        ))}
+        ))
+          : null}
         {showIdeaCategoryForm && (
           <IdeaCategoryForm
             onClose={() => setShowIdeaCategoryForm(false)}

--- a/GammaVase/src/pages/AdminPanel/AdminPanel.jsx
+++ b/GammaVase/src/pages/AdminPanel/AdminPanel.jsx
@@ -182,12 +182,12 @@ const AdminPanel = () => {
     }
   };
 
-  const guardarIdeaCategoria = async (name) => {
+  const guardarIdeaCategoria = async ({ name, imageUrl }) => {
     try {
       const res = await fetch('http://localhost:3000/api/ideas/categories', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name }),
+        body: JSON.stringify({ name, imageUrl }),
       });
       const data = await res.json();
       setIdeaCategories((prev) => [...prev, { ...data, cards: [] }]);
@@ -211,7 +211,13 @@ const AdminPanel = () => {
                 ...cat,
                 cards: [
                   ...cat.cards,
-                  { id: data.id, title: data.title, type: data.type, url: data.url },
+                  {
+                    id: data.id,
+                    title: data.title,
+                    type: data.type,
+                    url: data.url,
+                    imageUrl: data.imageUrl,
+                  },
                 ],
               }
             : cat

--- a/GammaVase/src/pages/AdminPanel/AdminPanel.jsx
+++ b/GammaVase/src/pages/AdminPanel/AdminPanel.jsx
@@ -49,9 +49,21 @@ const AdminPanel = () => {
       .then((data) => setPrecios(data));
 
     fetch('http://localhost:3000/api/ideas')
-      .then((res) => res.json())
-      .then((data) => setIdeaCategories(data))
-      .catch((err) => console.error('Error al cargar ideas', err));
+      .then((res) => {
+        if (!res.ok) throw new Error('Error al cargar ideas');
+        return res.json();
+      })
+      .then((data) => {
+        if (Array.isArray(data)) {
+          setIdeaCategories(data);
+        } else {
+          setIdeaCategories([]);
+        }
+      })
+      .catch((err) => {
+        console.error('Error al cargar ideas', err);
+        setIdeaCategories([]);
+      });
   }, []);
 
   const guardarFamilia = async (familia) => {
@@ -599,7 +611,7 @@ const AdminPanel = () => {
             ➕
           </span>
         </h2>
-        {ideaCategories.map((cat) => (
+        {Array.isArray(ideaCategories) && ideaCategories.map((cat) => (
           <div key={cat.id} className="idea-admin-category">
             <h3>
               {cat.name}{" "}

--- a/GammaVase/src/pages/Ideas/Ideas.css
+++ b/GammaVase/src/pages/Ideas/Ideas.css
@@ -74,28 +74,11 @@
 .idea-card:hover {
   transform: scale(1.03);
 }
+
 .idea-overlay {
   position: absolute;
   letter-spacing: 2px;
   font-family: "Kaushan Script", cursive;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.45);
-  color: white;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-weight: bold;
-  font-size: 1.1rem;
-  text-align: center;
-  padding: 0.5rem;
-}
-
-.idea-card:hover {
-  transform: scale(1.03);
-}
-
-.idea-overlay {
-  position: absolute;
   inset: 0;
   background: rgba(0, 0, 0, 0.45);
   color: white;
@@ -116,29 +99,12 @@
   z-index: 2;
 }
 
-.ideas-table-link {
-  display: block;
-  margin: 2rem auto 0;
+.ideas-back {
   text-align: center;
+  margin-top: 1rem;
+  cursor: pointer;
   color: #e75ec0;
   font-weight: bold;
-  text-decoration: none;
-}
-
-/* Estilos para categorías dinámicas */
-.idea-category {
-  background-color: #fff;
-  padding: 1rem;
-  border-radius: 8px;
-}
-
-.idea-category ul {
-  list-style: none;
-  padding: 0;
-}
-
-.idea-category li {
-  margin-bottom: 0.5rem;
 }
 @media (max-width: 600px) {
   .ideas-banner {

--- a/GammaVase/src/pages/Ideas/Ideas.jsx
+++ b/GammaVase/src/pages/Ideas/Ideas.jsx
@@ -1,12 +1,12 @@
 import React, { useEffect, useState } from "react";
 import "./Ideas.css";
 import TijerasImage from "../../components/Empresa/TijerasImage";
-import { Link } from "react-router-dom";
 import { motion } from "framer-motion";
 const MotionDiv = motion.div;
 
 const Ideas = () => {
   const [categories, setCategories] = useState([]);
+  const [selectedCategory, setSelectedCategory] = useState(null);
 
   useEffect(() => {
     fetch("http://localhost:3000/api/ideas")
@@ -33,36 +33,42 @@ const Ideas = () => {
         <TijerasImage />
 
         {/* Título Categorías */}
-        <h2 className="ideas-subtitle">Categorías</h2>
+        <h2 className="ideas-subtitle">
+          {selectedCategory ? selectedCategory.name : "Categorías"}
+        </h2>
 
-        {/* Categorías e items */}
+        {/* Grilla de categorías o subcategorías */}
         <div className="ideas-grid">
-          {categories.map((cat) => (
-            <div key={cat.id} className="idea-category">
-              <h3>{cat.name}</h3>
-              <ul>
-                {cat.cards.map((card) => (
-                  <li key={card.id}>
-                    {card.title}{" "}
-                    {card.type === "pdf" ? (
-                      <a href={card.url} target="_blank" rel="noopener noreferrer">
-                        Descargar PDF
-                      </a>
-                    ) : (
-                      <a href={card.url} target="_blank" rel="noopener noreferrer">
-                        Ver video
-                      </a>
-                    )}
-                  </li>
-                ))}
-              </ul>
-            </div>
-          ))}
+          {selectedCategory
+            ? selectedCategory.cards.map((card) => (
+                <a
+                  key={card.id}
+                  href={card.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="idea-card"
+                  style={{ backgroundImage: `url(${card.imageUrl})` }}
+                >
+                  <div className="idea-overlay">{card.title}</div>
+                </a>
+              ))
+            : categories.map((cat) => (
+                <div
+                  key={cat.id}
+                  className="idea-card"
+                  style={{ backgroundImage: `url(${cat.imageUrl})` }}
+                  onClick={() => setSelectedCategory(cat)}
+                >
+                  <div className="idea-overlay">{cat.name}</div>
+                </div>
+              ))}
         </div>
 
-        <Link to="/tabla-ideas" className="ideas-table-link">
-          Ver tabla de ideas
-        </Link>
+        {selectedCategory && (
+          <div className="ideas-back" onClick={() => setSelectedCategory(null)}>
+            ← Volver a categorías
+          </div>
+        )}
       </div>
     </MotionDiv>
   );


### PR DESCRIPTION
## Summary
- extend ideas API to include image URLs for categories and items
- show categories and subcategories as clickable image tiles
- enable admin panel forms to set category and item image URLs

## Testing
- `npm test` *(fails: Missing script: "test")*
- `timeout 5 node Backend/index.js` *(fails: Error al conectar con PostgreSQL)*

------
https://chatgpt.com/codex/tasks/task_e_68b78951e3548320bdfdfd325c9cec25