### PR TITLE
Handle errors when creating idea categories and items

### DIFF
--- a/GammaVase/src/pages/AdminPanel/AdminPanel.jsx
+++ b/GammaVase/src/pages/AdminPanel/AdminPanel.jsx
@@ -189,6 +189,11 @@ const AdminPanel = () => {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ name }),
       });
+      if (!res.ok) {
+        const error = await res.json();
+        alert(error.error || error.message || 'Error al guardar categoría');
+        return;
+      }
       const data = await res.json();
       setIdeaCategories((prev) => [...prev, { ...data, cards: [] }]);
     } catch (err) {
@@ -203,6 +208,11 @@ const AdminPanel = () => {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(item),
       });
+      if (!res.ok) {
+        const error = await res.json();
+        alert(error.error || error.message || 'Error al guardar idea');
+        return;
+      }
       const data = await res.json();
       setIdeaCategories((prev) =>
         prev.map((cat) =>


### PR DESCRIPTION
## Summary
- GuardarIdeaCategoria and guardarIdeaItem now verify `res.ok` before parsing responses
- Show server error messages without updating state when API calls fail

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b792fed598832095c51e3f8288fad3