### PR TITLE
refactor: improve ideas controller error handling

### DIFF
--- a/Backend/controllers/ideasController.js
+++ b/Backend/controllers/ideasController.js
@@ -1,32 +1,44 @@
 const pool = require('../db/db');
 
 const getIdeas = async (_req, res) => {
+  let categoriesRes;
   try {
-    const categoriesRes = await pool.query(
+    categoriesRes = await pool.query(
       'SELECT id, name FROM idea_categories ORDER BY id'
     );
-    const itemsRes = await pool.query(
+  } catch (err) {
+    console.error('Error fetching idea categories:', err);
+    return res
+      .status(500)
+      .json({ error: 'Failed to fetch idea categories', details: err.message });
+  }
+
+  let itemsRes;
+  try {
+    itemsRes = await pool.query(
       'SELECT id, category_id, title, type, url FROM idea_items ORDER BY id'
     );
-
-    const categories = categoriesRes.rows.map((cat) => ({
-      id: cat.id,
-      name: cat.name,
-      cards: itemsRes.rows
-        .filter((item) => item.category_id === cat.id)
-        .map((item) => ({
-          id: item.id,
-          title: item.title,
-          type: item.type,
-          url: item.url,
-        })),
-    }));
-
-    res.json(categories);
   } catch (err) {
-    console.error('Error fetching ideas', err);
-    res.status(500).json({ error: 'Error fetching ideas' });
+    console.error('Error fetching idea items:', err);
+    return res
+      .status(500)
+      .json({ error: 'Failed to fetch idea items', details: err.message });
   }
+
+  const categories = categoriesRes.rows.map((cat) => ({
+    id: cat.id,
+    name: cat.name,
+    cards: itemsRes.rows
+      .filter((item) => item.category_id === cat.id)
+      .map((item) => ({
+        id: item.id,
+        title: item.title,
+        type: item.type,
+        url: item.url,
+      })),
+  }));
+
+  res.json(categories);
 };
 
 const createCategory = async (req, res) => {
@@ -38,8 +50,10 @@ const createCategory = async (req, res) => {
     );
     res.status(201).json(result.rows[0]);
   } catch (err) {
-    console.error('Error creating category', err);
-    res.status(500).json({ error: 'Error creating category' });
+    console.error('Error creating category:', err);
+    res
+      .status(500)
+      .json({ error: 'Failed to create category', details: err.message });
   }
 };
 
@@ -54,8 +68,10 @@ const createItem = async (req, res) => {
     );
     res.status(201).json(result.rows[0]);
   } catch (err) {
-    console.error('Error creating item', err);
-    res.status(500).json({ error: 'Error creating item' });
+    console.error('Error creating item:', err);
+    res
+      .status(500)
+      .json({ error: 'Failed to create item', details: err.message });
   }
 };
 
@@ -78,8 +94,10 @@ const deleteCategory = async (req, res) => {
     res.sendStatus(204);
   } catch (err) {
     await client.query('ROLLBACK');
-    console.error('Error deleting category', err);
-    res.status(500).json({ error: 'Error deleting category' });
+    console.error('Error deleting category:', err);
+    res
+      .status(500)
+      .json({ error: 'Failed to delete category', details: err.message });
   } finally {
     client.release();
   }
@@ -96,8 +114,10 @@ const deleteItem = async (req, res) => {
 
     res.sendStatus(204);
   } catch (err) {
-    console.error('Error deleting item', err);
-    res.status(500).json({ error: 'Error deleting item' });
+    console.error('Error deleting item:', err);
+    res
+      .status(500)
+      .json({ error: 'Failed to delete item', details: err.message });
   }
 };
 


### PR DESCRIPTION
## Summary
- add granular error handling for fetching idea categories and items
- return detailed error messages when creating, deleting, and fetching ideas

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b7931a98848320ae179a525f6214f9