### PR TITLE
Make product catalog responsive

### DIFF
--- a/GammaVase/src/pages/Catalogo/ProductoCard.css
+++ b/GammaVase/src/pages/Catalogo/ProductoCard.css
@@ -1,5 +1,6 @@
 .card-producto {
-  width: 220px;
+  width: 100%;
+  max-width: 220px;
   background: #f5f5f5;
   border-radius: 20px;
   /* box-shadow: 0 2px 10px rgba(0, 0, 0, 0.12); */
@@ -57,14 +58,14 @@
 .precio-producto {
   color: #28a745;
   font-weight: bold;
-  font-size: 1.1rem;
+  font-size: clamp(0.9rem, 3vw, 1.1rem);
 }
 
 .acciones {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 0.4rem;
+  gap: clamp(0.3rem, 2vw, 0.4rem);
   margin-top: 0.3rem;
 }
 
@@ -77,14 +78,14 @@
   align-items: center;
   justify-content: center;
   overflow: hidden;
-  font-size: 1rem;
+  font-size: clamp(0.8rem, 2.5vw, 1rem);
 }
 
 .contador button {
   border: none;
   background: none;
   color: white;
-  font-size: 1.2rem;
+  font-size: clamp(1rem, 3vw, 1.2rem);
   padding: 0.2rem 0.6rem;
   cursor: pointer;
 }
@@ -102,7 +103,7 @@
   color: black;
   border: none;
   padding: 0.3rem 0.5rem;
-  font-size: 10rem;
+  font-size: clamp(0.9rem, 2.5vw, 1rem);
   font-weight: 800;
   cursor: pointer;
   display: flex;
@@ -114,4 +115,10 @@
 .btn-carrito:hover,
 .btn-vermas:hover {
   color: #444;
+}
+
+.btn-carrito svg,
+.btn-vermas svg {
+  width: clamp(18px, 4vw, 22px);
+  height: clamp(18px, 4vw, 22px);
 }

--- a/GammaVase/src/pages/Catalogo/ProductoCard.jsx
+++ b/GammaVase/src/pages/Catalogo/ProductoCard.jsx
@@ -62,10 +62,10 @@ const ProductoCard = ({ producto }) => {
           </div>
 
           <button className="btn-carrito" onClick={agregarAlCarrito}>
-            <ShoppingCart size={20} strokeWidth={2.5} />
+            <ShoppingCart strokeWidth={2.5} />
           </button>
           <Link to={`/productos/${producto.url}`} className="btn-vermas">
-            <Eye size={20} strokeWidth={2.5} />
+            <Eye strokeWidth={2.5} />
           </Link>
         </div>
       </div>

--- a/GammaVase/src/pages/Catalogo/catalogo.css
+++ b/GammaVase/src/pages/Catalogo/catalogo.css
@@ -59,8 +59,8 @@
 
 .productos-grid {
   display: grid;
-  grid-template-columns: repeat(3, 1fr); /* Solo 3 por fila */
-  gap: 1rem; /* Menor espacio entre ellas */
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 1rem;
   padding: 1rem 2rem;
 }
 

--- a/GammaVase/src/styles/Contacto/Contacto.css
+++ b/GammaVase/src/styles/Contacto/Contacto.css
@@ -1,7 +1,7 @@
 .contacto-container {
   font-family: "Onest", sans-serif;
-  padding: 2rem 5rem;
-  margin-top: -10rem;
+  padding: clamp(1rem, 4vw, 2rem) clamp(1rem, 7vw, 5rem);
+  margin-top: clamp(-10rem, -10vw, -3rem);
   display: flex;
   flex-direction: column;
 }
@@ -16,7 +16,7 @@
 
 /* Formulario */
 .formulario-box {
-  flex: 1 1 400px;
+  flex: 1 1 320px;
   display: flex;
   flex-direction: column;
   gap: 1rem;
@@ -24,7 +24,7 @@
 
 .titulo-formulario {
   font-weight: 800;
-  font-size: 2.5rem;
+  font-size: clamp(1.5rem, 6vw, 2.5rem);
 }
 
 form input,
@@ -46,7 +46,7 @@ form select {
 }
 
 #prefijo {
-  width: 10%;
+  width: clamp(4rem, 10%, 25%);
 }
 
 form input,
@@ -161,16 +161,3 @@ textarea {
   }
 }
 
-@media (max-width: 480px) {
-  .contacto-container {
-    padding: 1rem;
-  }
-
-  .titulo-formulario {
-    font-size: 2rem;
-  }
-
-  #prefijo {
-    width: 25%;
-  }
-}


### PR DESCRIPTION
## Summary
- Use auto-fill grid layout for catalog product grid
- Allow product cards to shrink and reduce action button size
- Scale quantity selector, price text, and action icons for small screens

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b8e290c0348320a8960336b09e3c13