### PR TITLE
Fix frontend fallback wildcard for Express 5 compatibility

### DIFF
--- a/Backend/index.js
+++ b/Backend/index.js
@@ -42,7 +42,7 @@ app.use('/familias', express.static(path.join(__dirname, '../GammaVase/public/as
 const frontendBuildPath = path.join(__dirname, '../GammaVase/dist');
 if (fs.existsSync(frontendBuildPath)) {
   app.use(express.static(frontendBuildPath));
-  app.get('*', (req, res, next) => {
+  app.get('/*', (req, res, next) => {
     if (req.path.startsWith('/api')) return next();
     return res.sendFile(path.join(frontendBuildPath, 'index.html'));
   });


### PR DESCRIPTION
### Motivation
- The server was crashing at startup with a `path-to-regexp` "Missing parameter name" error when using the previous catch-all route.
- Express 5's route matching requires a different wildcard pattern to avoid `path-to-regexp` parsing issues.
- Ensure the backend can serve the frontend `dist` fallback without interfering with `/api` routes.

### Description
- Replace `app.get('*', ...)` with `app.get('/*', ...)` in `Backend/index.js` to use an Express 5 compatible wildcard.
- Preserve the API exclusion `if (req.path.startsWith('/api')) return next();` and the static `dist` serving behavior.
- Change was committed to the repository (file: `Backend/index.js`).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961089058888331b75e4dc3ddd4052b)